### PR TITLE
Added markdig

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ A curated list of awesome .NET Performance books, courses, trainings, conference
 * [MathNet](http://www.mathdotnet.com/)
 * [Nessos Streams](https://github.com/nessos/Streams)
 * [SIMD Array](https://github.com/jackmott/SIMDArray)
+* [markdig](https://github.com/lunet-io/markdig)


### PR DESCRIPTION
Markdig is a very performant Markdown processor for .NET, both in terms of CPU and memory.

See [Implementing a Markdown Engine for .NET](http://xoofx.com/blog/2016/06/13/implementing-a-markdown-processor-for-dotnet/) and [README.md](https://github.com/lunet-io/markdig#benchmarking) for background and benchmarks.

Some bulletpoints:

- Markdig is roughly x100 times faster than MarkdownSharp, 30x times faster than docfx
- Among the best in CPU, Extremely competitive and often faster than other implementations (not feature wise equivalent)
- 15% to 30% less allocations and GC pressure