### PR TITLE
Added wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ A curated list of awesome .NET Performance books, courses, trainings, conference
 * [MathNet](http://www.mathdotnet.com/)
 * [Nessos Streams](https://github.com/nessos/Streams)
 * [SIMD Array](https://github.com/jackmott/SIMDArray)
+* [Wire](https://github.com/AsynkronIT/Wire)


### PR DESCRIPTION
Wire is an extremely fast and efficient binary serializer for POCOs. For some objects, even faster than protobuf.

See [Wire – Writing one of the fastest .NET serializers](https://rogeralsing.com/2016/08/16/wire-writing-one-of-the-fastest-net-serializers/) and [README.md](https://github.com/AsynkronIT/Wire#performance) for background and benchmarks.